### PR TITLE
Add tournament-scoped Pagos/Usuarios panels; hide club-only Overview …

### DIFF
--- a/src/sections/overview/app/view/overview-app-view.jsx
+++ b/src/sections/overview/app/view/overview-app-view.jsx
@@ -44,20 +44,32 @@ export function OverviewAppView() {
   const { user } = useAuthContext();
   const { selectedWorkspace, selectWorkspace, allWorkspaces } = useWorkspace();
 
+  // Tournament accounts don't have the club league features (calendar, voting,
+  // late-arrival points, workspace goals/assists) — mirrors filterClubOnlyNav
+  // in src/layouts/dashboard/layout.jsx.
+  const accountType = user?.accounts?.[user?.activeAccountId]?.settings?.account_type ?? 'club';
+  const isTournamentAccount = accountType === 'tournament';
+
   const { paymentRequests } = useGetPaymentRequestsByUser(user.id);
-  const { stadistics } = useGetUserAssistsStats(selectedWorkspace) || [];
-  const { events } = useGetEvents(selectedWorkspace);
-  const { topGoalsAndAssists } = useGetTopGoalsAndAssists(selectedWorkspace) || [];
+  const { stadistics } =
+    useGetUserAssistsStats(isTournamentAccount ? null : selectedWorkspace) || [];
+  const { events } = useGetEvents(isTournamentAccount ? null : selectedWorkspace);
+  const { topGoalsAndAssists } =
+    useGetTopGoalsAndAssists(isTournamentAccount ? null : selectedWorkspace) || [];
 
   const pendingOrOverduePaymentRequests = paymentRequests?.filter(
     (request) => request.status === 'pending' || request.status === 'overdue'
   );
 
   // Fast-path: same browser already has the flag
-  const [hasSeenTour, setHasSeenTour] = useState(() => !!localStorage.getItem('documents-feature-seen'));
+  const [hasSeenTour, setHasSeenTour] = useState(
+    () => !!localStorage.getItem('documents-feature-seen')
+  );
 
   // Only hit the API when the local flag is absent (new browser / incognito)
-  const { tourPreferences, tourPrefsLoading } = useGetTourPreferences(!hasSeenTour ? user.id : null);
+  const { tourPreferences, tourPrefsLoading } = useGetTourPreferences(
+    !hasSeenTour ? user.id : null
+  );
 
   const [tourHelpers, setTourHelpers] = useState(null);
   const [pendingWorkspace, setPendingWorkspace] = useState(null);
@@ -96,7 +108,7 @@ export function OverviewAppView() {
       hideCloseButton: true,
       content: (
         <Box sx={{ typography: 'body2', color: 'text.secondary' }}>
-          ¡Hemos agregado una potente función de Documentos! Ahora puedes ver todos los documentos 
+          ¡Hemos agregado una potente función de Documentos! Ahora puedes ver todos los documentos
           de tu Club al instante.
         </Box>
       ),
@@ -138,8 +150,8 @@ export function OverviewAppView() {
       placement: 'center',
       content: (
         <Box sx={{ typography: 'body2', color: 'text.secondary' }}>
-          Haz clic en &quot;Documentos&quot; en la barra lateral para comenzar a gestionar tus archivos. ¡Prueba
-          ver un PDF o descargar un archivo!
+          Haz clic en &quot;Documentos&quot; en la barra lateral para comenzar a gestionar tus
+          archivos. ¡Prueba ver un PDF o descargar un archivo!
         </Box>
       ),
     },
@@ -173,7 +185,7 @@ export function OverviewAppView() {
         selectWorkspace(pendingWorkspace);
       }
     }
-    
+
     // When tour completes, 'reset' action fires (before 'stop')
     if (action === 'reset') {
       localStorage.setItem('documents-feature-seen', 'true');
@@ -181,7 +193,7 @@ export function OverviewAppView() {
       markTourSeen(user.id, 'documents-feature');
       router.push(paths.dashboard.guide);
     }
-    
+
     walktour.onCallback(data);
   };
 
@@ -201,88 +213,90 @@ export function OverviewAppView() {
         disableBeacon
         disableOverlayClose
       />
-    <DashboardContent maxWidth="xl">
-      <Grid container spacing={3}>
-        {/* Votaciones Banner */}
-        <Grid xs={12}>
-          <Alert
-            severity="primary"
-            variant="standard"
-            icon={<Iconify icon="mdi:vote" width={24} />}
-            action={
-              <Button
-                color="primary"
-                size="small"
-                variant="outlined"
-                onClick={() => router.push(paths.dashboard.votaciones.root)}
-                endIcon={<Iconify icon="eva:arrow-ios-forward-fill" />}
-                sx={{ whiteSpace: 'nowrap' }}
+      <DashboardContent maxWidth="xl">
+        <Grid container spacing={3}>
+          {/* Votaciones Banner */}
+          {!isTournamentAccount && (
+            <Grid xs={12}>
+              <Alert
+                severity="primary"
+                variant="standard"
+                icon={<Iconify icon="mdi:vote" width={24} />}
+                action={
+                  <Button
+                    color="primary"
+                    size="small"
+                    variant="outlined"
+                    onClick={() => router.push(paths.dashboard.votaciones.root)}
+                    endIcon={<Iconify icon="eva:arrow-ios-forward-fill" />}
+                    sx={{ whiteSpace: 'nowrap' }}
+                  >
+                    Vota ya
+                  </Button>
+                }
+                sx={{
+                  alignItems: 'center',
+                  bgcolor: 'primary.lighter',
+                  color: 'primary.darker',
+                }}
               >
-                Vota ya
-              </Button>
-            }
-            sx={{ 
-              alignItems: 'center', 
-              bgcolor: 'primary.lighter',
-              color: 'primary.darker',
-            }}
-          >
-            ¡Participa en las votaciones activas de tu club y haz escuchar tu voz!
-          </Alert>
-        </Grid>
-
-        {/* Welcome / hero */}
-        <Grid xs={12} md={6}>
-          <AppWelcome
-            title={`${t('welcome_back')} ${user?.displayName}`}
-            description={t('we_re_vittoria')}
-          />
-        </Grid>
-
-        {/* Pending / overdue payments */}
-        <Grid xs={12} md={6}>
-          <AppNewInvoice
-            title="Pagos pendientes o vencidos"
-            tableData={pendingOrOverduePaymentRequests}
-            headLabel={[
-              { id: 'status', label: 'Estado' }, 
-              { id: 'totalAmount', label: 'Monto' },
-              { id: 'concept', label: 'Concepto' },
-              { id: 'dueDate', label: 'Vencimiento' },
-              { id: 'id', label: 'ID Pago' },
-            ]}
-          />
-        </Grid>
-
-        {/* Next events + upload voucher */}
-        <Grid xs={12} md={4}>
-          <Box sx={{ gap: 3, display: 'flex', flexDirection: 'column' }}>
-            <NextEvents title={t('next_events')} list={events} />
-            <FileUpgrade userId={user.id} />
-          </Box>
-        </Grid>
-
-        {/* Featured content + stats */}
-        <Grid xs={12} md={8}>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-            {/* <AppFeatured list={_appFeatured} /> */}
-
-            <Grid container spacing={3}>
-              <Grid xs={12} md={6}>
-                <CourseWidgetSummary title="Puntos llegadas tarde" list={stadistics} />
-              </Grid>
-
-              <Grid xs={12} md={6}>
-                <AppTopAuthors
-                  title={`${t('goals_and_assits')} ${selectedWorkspace?.name}`}
-                  list={orderBy(topGoalsAndAssists, ['goals'], ['desc']).slice(0, 3)}
-                />
-              </Grid>
+                ¡Participa en las votaciones activas de tu club y haz escuchar tu voz!
+              </Alert>
             </Grid>
-          </Box>
+          )}
+
+          {/* Welcome / hero */}
+          <Grid xs={12} md={6}>
+            <AppWelcome
+              title={`${t('welcome_back')} ${user?.displayName}`}
+              description={t('we_re_vittoria')}
+            />
+          </Grid>
+
+          {/* Pending / overdue payments */}
+          <Grid xs={12} md={6}>
+            <AppNewInvoice
+              title="Pagos pendientes o vencidos"
+              tableData={pendingOrOverduePaymentRequests}
+              headLabel={[
+                { id: 'status', label: 'Estado' },
+                { id: 'totalAmount', label: 'Monto' },
+                { id: 'concept', label: 'Concepto' },
+                { id: 'dueDate', label: 'Vencimiento' },
+                { id: 'id', label: 'ID Pago' },
+              ]}
+            />
+          </Grid>
+
+          {/* Next events + upload voucher */}
+          <Grid xs={12} md={isTournamentAccount ? 6 : 4}>
+            <Box sx={{ gap: 3, display: 'flex', flexDirection: 'column' }}>
+              {!isTournamentAccount && <NextEvents title={t('next_events')} list={events} />}
+              <FileUpgrade userId={user.id} />
+            </Box>
+          </Grid>
+
+          {/* Featured content + stats (club league only — tournaments have their own stats page) */}
+          {!isTournamentAccount && (
+            <Grid xs={12} md={8}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                <Grid container spacing={3}>
+                  <Grid xs={12} md={6}>
+                    <CourseWidgetSummary title="Puntos llegadas tarde" list={stadistics} />
+                  </Grid>
+
+                  <Grid xs={12} md={6}>
+                    <AppTopAuthors
+                      title={`${t('goals_and_assits')} ${selectedWorkspace?.name}`}
+                      list={orderBy(topGoalsAndAssists, ['goals'], ['desc']).slice(0, 3)}
+                    />
+                  </Grid>
+                </Grid>
+              </Box>
+            </Grid>
+          )}
         </Grid>
-      </Grid>
-    </DashboardContent>
+      </DashboardContent>
     </>
   );
 }

--- a/src/sections/tournament/tournament-banner.jsx
+++ b/src/sections/tournament/tournament-banner.jsx
@@ -122,8 +122,7 @@ export function getPhases(tournament, teams, totalMatchweeks, myRoster) {
       // For knockout-only: always accessible once active.
       // For hybrid: only after all group-stage jornadas are done.
       const groupsDone = type === 'knockout' || (totalMw > 0 && currentMw >= totalMw);
-      const bracketGenerated =
-        tournament.bracket && Object.keys(tournament.bracket).length > 0;
+      const bracketGenerated = tournament.bracket && Object.keys(tournament.bracket).length > 0;
       phases.push({
         key: 'eliminatorias',
         label: 'Fase Final',
@@ -160,6 +159,8 @@ export function TournamentBanner({
   onFinish,
   onDelete,
   onOpenDiscipline,
+  onOpenPayments,
+  onOpenUsers,
   onAdvanceMatchweek,
   onNavigateEdit,
   publicMode = false,
@@ -178,9 +179,7 @@ export function TournamentBanner({
   const phases = getPhases(tournament, teams, totalMw, myRoster);
 
   const allGroupMatchesFinished =
-    !allMatches ||
-    allMatches.length === 0 ||
-    allMatches.every((m) => m.status === 'finished');
+    !allMatches || allMatches.length === 0 || allMatches.every((m) => m.status === 'finished');
 
   const hasBracket = tournament.bracket && Object.keys(tournament.bracket).length > 0;
 
@@ -306,105 +305,135 @@ export function TournamentBanner({
 
             {/* Action Buttons (hidden in public/read-only mode) */}
             {!publicMode && (
-            <Stack direction="row" spacing={1} flexWrap="wrap">
-              {tournament.status === 'draft' && (
-                <Tooltip
-                  title={!canActivate ? 'Se necesitan al menos 2 equipos' : ''}
-                  arrow
-                >
-                  <span>
+              <Stack direction="row" spacing={1} flexWrap="wrap">
+                {tournament.status === 'draft' && (
+                  <Tooltip title={!canActivate ? 'Se necesitan al menos 2 equipos' : ''} arrow>
+                    <span>
+                      <LoadingButton
+                        variant="contained"
+                        color="success"
+                        size="small"
+                        startIcon={<Iconify icon="mdi:play" width={16} />}
+                        loading={isSubmitting}
+                        onClick={onActivate}
+                        disabled={!canActivate}
+                      >
+                        Activar
+                      </LoadingButton>
+                    </span>
+                  </Tooltip>
+                )}
+
+                {tournament.status === 'active' &&
+                  (isLeague || isHybrid) &&
+                  totalMw > 0 &&
+                  currentMw < totalMw && (
                     <LoadingButton
-                      variant="contained"
-                      color="success"
+                      variant="outlined"
                       size="small"
-                      startIcon={<Iconify icon="mdi:play" width={16} />}
+                      startIcon={<Iconify icon="mdi:skip-next" width={16} />}
                       loading={isSubmitting}
-                      onClick={onActivate}
-                      disabled={!canActivate}
+                      onClick={onAdvanceMatchweek}
                     >
-                      Activar
+                      Avanzar Jornada
                     </LoadingButton>
-                  </span>
-                </Tooltip>
-              )}
+                  )}
 
-              {tournament.status === 'active' && (isLeague || isHybrid) && totalMw > 0 && currentMw < totalMw && (
-                <LoadingButton
-                  variant="outlined"
-                  size="small"
-                  startIcon={<Iconify icon="mdi:skip-next" width={16} />}
-                  loading={isSubmitting}
-                  onClick={onAdvanceMatchweek}
-                >
-                  Avanzar Jornada
-                </LoadingButton>
-              )}
-
-              {isHybrid && tournament.status === 'active' && totalMw > 0 && currentMw >= totalMw && !hasBracket && (
-                <Tooltip
-                  title={!allGroupMatchesFinished ? 'Hay partidos pendientes en la fase de grupos' : ''}
-                  arrow
-                >
-                  <span>
-                    <Button
-                      variant="contained"
-                      color="success"
-                      size="small"
-                      startIcon={<Iconify icon="mdi:tournament" width={16} />}
-                      disabled={!allGroupMatchesFinished}
-                      onClick={() => onPhaseClick?.('eliminatorias')}
+                {isHybrid &&
+                  tournament.status === 'active' &&
+                  totalMw > 0 &&
+                  currentMw >= totalMw &&
+                  !hasBracket && (
+                    <Tooltip
+                      title={
+                        !allGroupMatchesFinished
+                          ? 'Hay partidos pendientes en la fase de grupos'
+                          : ''
+                      }
+                      arrow
                     >
-                      Iniciar Fase Final
-                    </Button>
-                  </span>
-                </Tooltip>
-              )}
+                      <span>
+                        <Button
+                          variant="contained"
+                          color="success"
+                          size="small"
+                          startIcon={<Iconify icon="mdi:tournament" width={16} />}
+                          disabled={!allGroupMatchesFinished}
+                          onClick={() => onPhaseClick?.('eliminatorias')}
+                        >
+                          Iniciar Fase Final
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  )}
 
-              {tournament.status === 'active' && (
-                <LoadingButton
-                  variant="outlined"
-                  color="info"
-                  size="small"
-                  startIcon={<Iconify icon="mdi:flag-checkered" width={16} />}
-                  loading={isSubmitting}
-                  onClick={onFinish}
-                >
-                  Finalizar
-                </LoadingButton>
-              )}
+                {tournament.status === 'active' && (
+                  <LoadingButton
+                    variant="outlined"
+                    color="info"
+                    size="small"
+                    startIcon={<Iconify icon="mdi:flag-checkered" width={16} />}
+                    loading={isSubmitting}
+                    onClick={onFinish}
+                  >
+                    Finalizar
+                  </LoadingButton>
+                )}
 
-              {onOpenDiscipline && (
+                {onOpenDiscipline && (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<Iconify icon="mdi:card-multiple" width={16} />}
+                    onClick={onOpenDiscipline}
+                  >
+                    Sanciones
+                  </Button>
+                )}
+
+                {onOpenPayments && (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<Iconify icon="solar:dollar-minimalistic-bold" width={16} />}
+                    onClick={onOpenPayments}
+                  >
+                    Pagos
+                  </Button>
+                )}
+
+                {onOpenUsers && (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<Iconify icon="mdi:account-group-outline" width={16} />}
+                    onClick={onOpenUsers}
+                  >
+                    Usuarios
+                  </Button>
+                )}
+
+                {tournament.status !== 'finished' && (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<Iconify icon="solar:pen-bold" width={16} />}
+                    onClick={onNavigateEdit}
+                  >
+                    Editar
+                  </Button>
+                )}
+
                 <Button
-                  variant="outlined"
+                  variant="soft"
+                  color="error"
                   size="small"
-                  startIcon={<Iconify icon="mdi:card-multiple" width={16} />}
-                  onClick={onOpenDiscipline}
+                  startIcon={<Iconify icon="solar:trash-bin-trash-bold" width={16} />}
+                  onClick={onDelete}
                 >
-                  Sanciones
+                  Eliminar
                 </Button>
-              )}
-
-              {tournament.status !== 'finished' && (
-                <Button
-                  variant="outlined"
-                  size="small"
-                  startIcon={<Iconify icon="solar:pen-bold" width={16} />}
-                  onClick={onNavigateEdit}
-                >
-                  Editar
-                </Button>
-              )}
-
-              <Button
-                variant="soft"
-                color="error"
-                size="small"
-                startIcon={<Iconify icon="solar:trash-bin-trash-bold" width={16} />}
-                onClick={onDelete}
-              >
-                Eliminar
-              </Button>
-            </Stack>
+              </Stack>
             )}
           </Stack>
         </Stack>

--- a/src/sections/tournament/tournament-payments-table.jsx
+++ b/src/sections/tournament/tournament-payments-table.jsx
@@ -1,0 +1,92 @@
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Avatar from '@mui/material/Avatar';
+import { alpha } from '@mui/material/styles';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
+
+import { fDate } from 'src/utils/format-time';
+import { fCurrency } from 'src/utils/format-number';
+
+import { useGetPaymentRequests } from 'src/actions/paymentRequest';
+
+import { EmptyContent } from 'src/components/empty-content';
+
+// ----------------------------------------------------------------------
+
+const STATUS_META = {
+  paid: { label: 'Pagado', color: 'success' },
+  pending: { label: 'Pendiente', color: 'warning' },
+  overdue: { label: 'Vencido', color: 'error' },
+  approval_pending: { label: 'En revisión', color: 'secondary' },
+  canceled: { label: 'Cancelado', color: 'default' },
+};
+
+/**
+ * Payment requests generated for a tournament (e.g. via "Generar Cobros").
+ * These are grouped by tournamentId rather than a workspace, so they're
+ * fetched here instead of the workspace-scoped invoice views.
+ */
+export function TournamentPaymentsTable({ tournamentId }) {
+  const { paymentRequests, paymentRequestsLoading } = useGetPaymentRequests(tournamentId);
+
+  if (paymentRequestsLoading) {
+    return (
+      <Stack spacing={1}>
+        {[...Array(4)].map((_, i) => (
+          <Skeleton key={i} variant="rounded" height={56} />
+        ))}
+      </Stack>
+    );
+  }
+
+  if (!paymentRequests?.length) {
+    return <EmptyContent title="Sin cobros generados todavía" sx={{ py: 6 }} />;
+  }
+
+  return (
+    <Stack spacing={0.75}>
+      {paymentRequests.map((pr) => {
+        const recipient = pr.paymentRequestTo?.[0];
+        const meta = STATUS_META[pr.status] || STATUS_META.pending;
+        return (
+          <Box
+            key={pr.id}
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr auto auto',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 2,
+              py: 1.25,
+              bgcolor: 'background.paper',
+              border: (t) => `1px solid ${alpha(t.palette.grey[500], 0.08)}`,
+              borderRadius: 1,
+            }}
+          >
+            <Stack direction="row" alignItems="center" spacing={1.25}>
+              <Avatar sx={{ width: 32, height: 32 }}>
+                {(recipient?.name || '?').charAt(0).toUpperCase()}
+              </Avatar>
+              <Stack spacing={0.25}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                  {pr.concept}
+                </Typography>
+                <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+                  {recipient?.name || 'Sin destinatario'} · Vence {fDate(pr.dueDate)}
+                </Typography>
+              </Stack>
+            </Stack>
+
+            <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+              {fCurrency(pr.totalAmount)}
+            </Typography>
+
+            <Chip size="small" variant="soft" color={meta.color} label={meta.label} />
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/src/sections/tournament/tournament-users-table.jsx
+++ b/src/sections/tournament/tournament-users-table.jsx
@@ -1,0 +1,82 @@
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Avatar from '@mui/material/Avatar';
+import { alpha } from '@mui/material/styles';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
+
+import { EmptyContent } from 'src/components/empty-content';
+
+// ----------------------------------------------------------------------
+
+/**
+ * Team managers/contacts for a tournament — the people "Generar Cobros" bills.
+ * Built from the teams already loaded for the tournament, since manager info
+ * (manager_name, contact_email, manager_user_ids) already lives on the team.
+ */
+export function TournamentUsersTable({ teams, teamsLoading }) {
+  if (teamsLoading) {
+    return (
+      <Stack spacing={1}>
+        {[...Array(4)].map((_, i) => (
+          <Skeleton key={i} variant="rounded" height={56} />
+        ))}
+      </Stack>
+    );
+  }
+
+  if (!teams?.length) {
+    return <EmptyContent title="Sin equipos inscritos todavía" sx={{ py: 6 }} />;
+  }
+
+  return (
+    <Stack spacing={0.75}>
+      {teams.map((team) => {
+        const isRegistered = (team.manager_user_ids || []).length > 0;
+        const initials = team.short_name || team.name?.slice(0, 2)?.toUpperCase() || '?';
+        return (
+          <Box
+            key={team.id}
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr auto',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 2,
+              py: 1.25,
+              bgcolor: 'background.paper',
+              border: (t) => `1px solid ${alpha(t.palette.grey[500], 0.08)}`,
+              borderRadius: 1,
+            }}
+          >
+            <Stack direction="row" alignItems="center" spacing={1.25}>
+              <Avatar
+                src={team.logo_url || undefined}
+                variant="rounded"
+                sx={{ width: 32, height: 32 }}
+              >
+                {!team.logo_url && initials}
+              </Avatar>
+              <Stack spacing={0.25}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                  {team.manager_name || 'Sin encargado'}
+                </Typography>
+                <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+                  {team.name} · {team.contact_email || 'Sin email'}
+                </Typography>
+              </Stack>
+            </Stack>
+
+            <Chip
+              size="small"
+              variant="soft"
+              color={isRegistered ? 'success' : 'default'}
+              label={isRegistered ? 'Registrado' : 'Pendiente'}
+            />
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/src/sections/tournament/view/tournament-detail-view.jsx
+++ b/src/sections/tournament/view/tournament-detail-view.jsx
@@ -40,6 +40,8 @@ import { Iconify } from 'src/components/iconify';
 import { EmptyContent } from 'src/components/empty-content';
 import { LoadingScreen } from 'src/components/loading-screen';
 
+import { useAuthContext } from 'src/auth/hooks';
+
 import { TeamList } from '../team-list';
 import { BracketView } from '../bracket-view';
 import { StatsOverview } from '../stats-overview';
@@ -48,8 +50,10 @@ import { MatchweekTimeline } from '../matchweek-timeline';
 import { PlayerRankingTable } from '../player-ranking-table';
 import { MatchList, MatchScheduleDialog } from '../match-row';
 import { TeamDisciplineTable } from '../team-discipline-table';
+import { TournamentUsersTable } from '../tournament-users-table';
 import { getPhases, TournamentBanner } from '../tournament-banner';
 import { TournamentConfigSummary } from '../tournament-config-summary';
+import { TournamentPaymentsTable } from '../tournament-payments-table';
 
 // ----------------------------------------------------------------------
 
@@ -77,8 +81,9 @@ export function TournamentDetailView() {
   const { id } = useParams();
   const navigate = useNavigate();
 
+  const { user } = useAuthContext();
   const { tournament, tournamentLoading } = useGetTournament(id);
-  const { teams } = useGetTeams(id);
+  const { teams, teamsLoading } = useGetTeams(id);
   const { groups } = useGetGroups(id);
   const { stats } = useGetStats(id);
   const { matches: allMatches, matchesLoading } = useGetMatches(id);
@@ -86,6 +91,11 @@ export function TournamentDetailView() {
 
   const { workspaceRole } = useWorkspace();
   const isAdmin = workspaceRole === 'admin';
+  // GET /payment_requests is gated by ACCOUNT role, not workspace role (unlike the
+  // workspace-scoped mutations below), so it needs the same account-role fallback
+  // used for the account-role-gated "Generar Cobros" endpoint in match-detail-view.jsx.
+  const isAccountAdmin = user?.accountsRoles?.[user?.activeAccountId] === 'admin';
+  const canViewTournamentPayments = isAdmin || isAccountAdmin;
 
   const [activePhase, setActivePhase] = useState(null);
   const [selectedMatchweek, setSelectedMatchweek] = useState(undefined);
@@ -95,6 +105,8 @@ export function TournamentDetailView() {
   const [deleteDialog, setDeleteDialog] = useState(false);
   const [scheduleDialog, setScheduleDialog] = useState(false);
   const [disciplineOpen, setDisciplineOpen] = useState(false);
+  const [paymentsOpen, setPaymentsOpen] = useState(false);
+  const [usersOpen, setUsersOpen] = useState(false);
   const [scheduleMatch, setScheduleMatch] = useState(null);
   const [scheduleForm, setScheduleForm] = useState({
     start_date: new Date().toISOString().split('T')[0],
@@ -104,7 +116,8 @@ export function TournamentDetailView() {
   });
 
   // Resolve active phase (lazy init after tournament loads)
-  const currentPhase = activePhase || (tournament ? getDefaultPhase(tournament, teams) : 'configuracion');
+  const currentPhase =
+    activePhase || (tournament ? getDefaultPhase(tournament, teams) : 'configuracion');
 
   // Derive current matchweek
   const currentMw = tournament?.current_matchweek || 1;
@@ -122,7 +135,10 @@ export function TournamentDetailView() {
 
   // Next pending match for sidebar action
   const nextPendingMatch = useMemo(
-    () => allMatches.find((m) => m.matchweek === currentMw && m.status !== 'finished' && m.status !== 'cancelled'),
+    () =>
+      allMatches.find(
+        (m) => m.matchweek === currentMw && m.status !== 'finished' && m.status !== 'cancelled'
+      ),
     [allMatches, currentMw]
   );
 
@@ -172,9 +188,7 @@ export function TournamentDetailView() {
         const mwMatches = res.data || [];
         const unfinished = mwMatches.filter((m) => m.status !== 'finished');
         if (unfinished.length > 0) {
-          toast.error(
-            `Faltan ${unfinished.length} partido(s) por finalizar en Jornada ${mw}`
-          );
+          toast.error(`Faltan ${unfinished.length} partido(s) por finalizar en Jornada ${mw}`);
           return;
         }
       }
@@ -254,11 +268,12 @@ export function TournamentDetailView() {
         onAdvanceMatchweek={handleAdvanceMatchweek}
         onNavigateEdit={() => navigate(paths.dashboard.tournament.edit(id))}
         onOpenDiscipline={() => setDisciplineOpen(true)}
+        onOpenPayments={canViewTournamentPayments ? () => setPaymentsOpen(true) : undefined}
+        onOpenUsers={canViewTournamentPayments ? () => setUsersOpen(true) : undefined}
       />
 
       {/* ═══ Phase Content ═══ */}
       <Box sx={{ bgcolor: (t) => alpha(t.palette.grey[500], 0.02), minHeight: 400 }}>
-
         {/* ── CONFIGURACIÓN: Tournament overview, stats ── */}
         {currentPhase === 'configuracion' && (
           <Stack spacing={2.5} sx={{ p: { xs: 2, md: 3 } }}>
@@ -299,7 +314,9 @@ export function TournamentDetailView() {
                   <Typography variant="caption" sx={{ color: 'text.disabled', fontWeight: 600 }}>
                     {activeMw === null ? 'Todos los partidos' : `Jornada ${activeMw}`}
                   </Typography>
-                  <Box sx={{ flex: 1, height: 1, bgcolor: (t) => alpha(t.palette.grey[500], 0.08) }} />
+                  <Box
+                    sx={{ flex: 1, height: 1, bgcolor: (t) => alpha(t.palette.grey[500], 0.08) }}
+                  />
                 </Stack>
 
                 {matchesLoading ? (
@@ -340,30 +357,33 @@ export function TournamentDetailView() {
               </Box>
             </Grid>
 
-              {/* Right: standings */}
-              <Grid xs={12} md={6}>
-                <StandingsSidebar
-                  tournamentId={id}
-                  teams={teams}
-                  allMatches={allMatches}
-                  nextPendingMatch={nextPendingMatch}
-                  currentMatchweek={currentMw}
-                  totalMatchweeks={totalMw}
-                  onNextAction={
-                    isAdmin && nextPendingMatch
-                      ? () => handleScoreClick(nextPendingMatch)
-                      : undefined
-                  }
-                />
-              </Grid>
-
+            {/* Right: standings */}
+            <Grid xs={12} md={6}>
+              <StandingsSidebar
+                tournamentId={id}
+                teams={teams}
+                allMatches={allMatches}
+                nextPendingMatch={nextPendingMatch}
+                currentMatchweek={currentMw}
+                totalMatchweeks={totalMw}
+                onNextAction={
+                  isAdmin && nextPendingMatch ? () => handleScoreClick(nextPendingMatch) : undefined
+                }
+              />
             </Grid>
+          </Grid>
         )}
 
         {/* ── KNOCKOUT PHASES: Bracket view ── */}
         {isKnockoutPhase && (
           <Box sx={{ p: { xs: 2, md: 3 } }}>
-            <BracketView tournamentId={id} teams={teams} tournament={tournament} allMatches={allMatches} readOnly={!isAdmin} />
+            <BracketView
+              tournamentId={id}
+              teams={teams}
+              tournament={tournament}
+              allMatches={allMatches}
+              readOnly={!isAdmin}
+            />
           </Box>
         )}
 
@@ -395,12 +415,17 @@ export function TournamentDetailView() {
       {/* ═══ Dialogs ═══ */}
 
       {/* Activate confirmation */}
-      <Dialog open={activateDialog} onClose={() => setActivateDialog(false)} maxWidth="xs" fullWidth>
+      <Dialog
+        open={activateDialog}
+        onClose={() => setActivateDialog(false)}
+        maxWidth="xs"
+        fullWidth
+      >
         <DialogTitle>Activar Torneo</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Al activar el torneo no podrás agregar ni eliminar equipos. ¿Confirmas que deseas activar{' '}
-            <strong>{tournament.name}</strong>?
+            Al activar el torneo no podrás agregar ni eliminar equipos. ¿Confirmas que deseas
+            activar <strong>{tournament.name}</strong>?
           </DialogContentText>
         </DialogContent>
         <DialogActions>
@@ -421,8 +446,8 @@ export function TournamentDetailView() {
         <DialogTitle>Finalizar Torneo</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Esto marcará el torneo como <strong>Finalizado</strong>. Podrás reabrirlo si es necesario.
-            ¿Confirmas?
+            Esto marcará el torneo como <strong>Finalizado</strong>. Podrás reabrirlo si es
+            necesario. ¿Confirmas?
           </DialogContentText>
         </DialogContent>
         <DialogActions>
@@ -461,7 +486,12 @@ export function TournamentDetailView() {
       </Dialog>
 
       {/* Schedule Generation Dialog */}
-      <Dialog open={scheduleDialog} onClose={() => setScheduleDialog(false)} maxWidth="sm" fullWidth>
+      <Dialog
+        open={scheduleDialog}
+        onClose={() => setScheduleDialog(false)}
+        maxWidth="sm"
+        fullWidth
+      >
         <DialogTitle>Generar Calendario</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
@@ -509,7 +539,11 @@ export function TournamentDetailView() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setScheduleDialog(false)}>Cancelar</Button>
-          <LoadingButton variant="contained" loading={isSubmitting} onClick={handleGenerateSchedule}>
+          <LoadingButton
+            variant="contained"
+            loading={isSubmitting}
+            onClick={handleGenerateSchedule}
+          >
             Generar
           </LoadingButton>
         </DialogActions>
@@ -551,6 +585,56 @@ export function TournamentDetailView() {
               navigate(paths.dashboard.tournament.matchDetail(id, matchId));
             }}
           />
+        </Box>
+      </Drawer>
+
+      {/* Pagos drawer — payment requests generated for this tournament */}
+      <Drawer
+        anchor="right"
+        open={paymentsOpen}
+        onClose={() => setPaymentsOpen(false)}
+        PaperProps={{ sx: { width: { xs: '100%', sm: 520, md: 640 } } }}
+      >
+        <Box sx={{ p: 2.5, borderBottom: (t) => `1px solid ${alpha(t.palette.grey[500], 0.12)}` }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Stack>
+              <Typography variant="h6">Pagos</Typography>
+              <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+                Cobros generados para este torneo
+              </Typography>
+            </Stack>
+            <IconButton onClick={() => setPaymentsOpen(false)}>
+              <Iconify icon="eva:close-fill" width={20} />
+            </IconButton>
+          </Stack>
+        </Box>
+        <Box sx={{ p: 2 }}>
+          <TournamentPaymentsTable tournamentId={id} />
+        </Box>
+      </Drawer>
+
+      {/* Usuarios drawer — team managers/contacts billed by this tournament */}
+      <Drawer
+        anchor="right"
+        open={usersOpen}
+        onClose={() => setUsersOpen(false)}
+        PaperProps={{ sx: { width: { xs: '100%', sm: 520, md: 640 } } }}
+      >
+        <Box sx={{ p: 2.5, borderBottom: (t) => `1px solid ${alpha(t.palette.grey[500], 0.12)}` }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Stack>
+              <Typography variant="h6">Usuarios</Typography>
+              <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+                Encargados de equipo del torneo
+              </Typography>
+            </Stack>
+            <IconButton onClick={() => setUsersOpen(false)}>
+              <Iconify icon="eva:close-fill" width={20} />
+            </IconButton>
+          </Stack>
+        </Box>
+        <Box sx={{ p: 2 }}>
+          <TournamentUsersTable teams={teams} teamsLoading={teamsLoading} />
         </Box>
       </Drawer>
     </DashboardContent>


### PR DESCRIPTION
…widgets for tournament accounts

Generar Cobros writes payment requests with user_group=tournamentId, but every workspace view filters by workspace_id, so tournament charges were invisible. Instead of forcing them into the workspace model, expose them via new tournament-scoped Pagos/Usuarios drawers on the tournament detail page, reusing the existing generic payment-requests list endpoint. Also trims the club-league-only widgets (voting, calendar, late-arrival points, workspace goals/assists) from the dashboard Overview when account_type is "tournament".