### PR TITLE
Show description as secondary line under Concepto in Pagos Totales

### DIFF
--- a/src/sections/invoice/invoice-table-row.jsx
+++ b/src/sections/invoice/invoice-table-row.jsx
@@ -101,7 +101,14 @@ export function InvoiceTableRow({
         <TableCell>
           <ListItemText
             primary={row.concept}
+            secondary={row.description}
             primaryTypographyProps={{ typography: 'body2', noWrap: true }}
+            secondaryTypographyProps={{
+              mt: 0.5,
+              component: 'span',
+              typography: 'caption',
+              noWrap: true,
+            }}
           />
         </TableCell>
 


### PR DESCRIPTION
Match/opponent info was already being computed by Generar Cobros (description field) but never rendered — every card charge for the same tournament looked identical in the table. Paired with the backend change adding the player's name to concept, rows are now distinguishable.