### PR TITLE
fix: allow selecting incoming player for substitutions, fix penalty_m…

### DIFF
--- a/src/locales/langs/en/common.json
+++ b/src/locales/langs/en/common.json
@@ -1344,6 +1344,8 @@
   "label_player_jersey_hint": "Player's jersey number",
   "label_no_assist": "No assist",
   "label_assist_optional": "Assist (optional)",
+  "label_player_out": "Player out",
+  "label_player_in": "Player in",
   "label_edit_player": "Edit Player",
   "label_player_created": "Player created",
   "label_player_updated": "Player updated",

--- a/src/locales/langs/es/common.json
+++ b/src/locales/langs/es/common.json
@@ -1344,6 +1344,8 @@
   "label_player_jersey_hint": "Dorsal del jugador",
   "label_no_assist": "Sin asistencia",
   "label_assist_optional": "Asistencia (opcional)",
+  "label_player_out": "Jugador que sale",
+  "label_player_in": "Jugador que entra",
   "label_edit_player": "Editar Jugador",
   "label_player_created": "Jugador creado",
   "label_player_updated": "Jugador actualizado",

--- a/src/sections/tournament/match-row.jsx
+++ b/src/sections/tournament/match-row.jsx
@@ -49,6 +49,12 @@ export const EVENT_CONFIG = {
     color: 'success.main',
     label: 'label_penalty',
   },
+  penalty_missed: {
+    type: 'penalty_missed',
+    icon: 'mdi:target',
+    color: 'error.main',
+    label: 'label_penalty_missed',
+  },
   yellow_card: {
     type: 'yellow_card',
     icon: 'mdi:card',

--- a/src/sections/tournament/view/match-detail-view.jsx
+++ b/src/sections/tournament/view/match-detail-view.jsx
@@ -816,7 +816,11 @@ export function MatchDetailView() {
             <TextField
               select
               fullWidth
-              label={t('label_player_singular')}
+              label={
+                eventForm.type === 'substitution'
+                  ? t('label_player_out')
+                  : t('label_player_singular')
+              }
               value={eventForm.player_id}
               onChange={(e) => setEventForm((f) => ({ ...f, player_id: e.target.value }))}
             >
@@ -828,15 +832,21 @@ export function MatchDetailView() {
                   </MenuItem>
                 ))}
             </TextField>
-            {['goal', 'penalty_scored'].includes(eventForm.type) && (
+            {['goal', 'penalty_scored', 'substitution'].includes(eventForm.type) && (
               <TextField
                 select
                 fullWidth
-                label={t('label_assist_optional')}
+                label={
+                  eventForm.type === 'substitution'
+                    ? t('label_player_in')
+                    : t('label_assist_optional')
+                }
                 value={eventForm.assist_player_id}
                 onChange={(e) => setEventForm((f) => ({ ...f, assist_player_id: e.target.value }))}
               >
-                <MenuItem value="">{t('label_no_assist')}</MenuItem>
+                {eventForm.type !== 'substitution' && (
+                  <MenuItem value="">{t('label_no_assist')}</MenuItem>
+                )}
                 {matchPlayers
                   .filter((p) => !eventForm.team_id || p.team_id === eventForm.team_id)
                   .filter((p) => p.id !== eventForm.player_id)
@@ -851,7 +861,12 @@ export function MatchDetailView() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setEventDialog(false)}>{t('cancel')}</Button>
-          <LoadingButton variant="contained" loading={isSubmitting} onClick={handleAddEvent}>
+          <LoadingButton
+            variant="contained"
+            loading={isSubmitting}
+            disabled={eventForm.type === 'substitution' && !eventForm.assist_player_id}
+            onClick={handleAddEvent}
+          >
             {t('label_register')}
           </LoadingButton>
         </DialogActions>


### PR DESCRIPTION
…issed display

Substitution events could only record the outgoing player — the "player in" select was gated to goal/penalty_scored types, so there was no way to record who came on. Also add the missing penalty_missed entry to match-row.jsx's EVENT_CONFIG, which was falling back to the goal config and rendering missed penalties as scored goals.